### PR TITLE
Rename description to describe

### DIFF
--- a/__tests__/base.test.js
+++ b/__tests__/base.test.js
@@ -37,15 +37,15 @@ describe('constructor', () => {
   });
 });
 
-describe('description', () => {
+describe('describe', () => {
   it('takes in a string', () => {
-    const base = new Base(name).description(description);
+    const base = new Base(name).describe(description);
     expect(base.description).toEqual(description);
   });
 
   it('throws if description is invalid', () => {
     const base = new Base(name);
-    expect(() => base.description(5)).toThrow();
+    expect(() => base.describe(5)).toThrow();
   });
 });
 
@@ -65,9 +65,9 @@ describe('nonNull', () => {
 });
 
 describe('clone', () => {
-  const base = new Base(name).description(description);
+  const base = new Base(name).describe(description);
   const clonedBase = base.clone();
-  const fakeBase = new FakeBase(name).description(description);
+  const fakeBase = new FakeBase(name).describe(description);
   const fakeClonedBase = fakeBase.clone();
 
   it('is instance of Base class', () => {
@@ -94,7 +94,7 @@ describe('clone', () => {
 
 describe('create', () => {
   it('creates a GraphQLScalarType type', () => {
-    const scalar = new FakeBase(name).description(description).create();
+    const scalar = new FakeBase(name).describe(description).create();
     expect(scalar).toBeInstanceOf(GraphQLScalarType);
     expect(scalar.name).toEqual(name);
     expect(scalar.description).toEqual(description);

--- a/src/base.js
+++ b/src/base.js
@@ -40,7 +40,7 @@ class Base<TInternal, TExternal> {
   /**
    * Gives a description to the GraphQLScalar.
    */
-  description(description: string) {
+  describe(description: string) {
     if (typeof description !== 'string') {
       throw new TypeError('description must be a string');
     }


### PR DESCRIPTION
- [X] Breaking change

Fixes a bug when `description` is never called resulting in a thrown error when running introspection queries. Because `description` is never called the scalar object type never overwrites the `description` property with the string value. To avoid this conflict, we can just rename `description` to describe` and resolution will therefore not try to use the default function. This is the unexpected error that you would have to dig into this module in order to diagnose:

```ReferenceError: description is not defined
    at StringScalar.create (node_modules/graphql-scalar-types/lib/base.js:85:19)
    at StringScalar.create (node_modules/graphql-scalar-types/lib/string.js:303:118)
```

As soon as I started calling `.description` it went away. Rather than try to detect if it was called, I decided to rename the function for simplicity sake. I like that it kinda fits in to the API with `.create` verbage.

Cheers!