### PR TITLE
Add apollo-server example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,57 @@ export const GraphQLName = GraphQLScalarTypes.string('Name').min(0).max(36).crea
 export const GraphQLAge = GraphQLScalarTypes.number('Age').min(0).max(120).create();
 ```
 
+### Using Apollo-Server
+
+Here is a minimal example using Apollo Server:
+
+```js
+const { ApolloServer, gql } = require('apollo-server');
+const { default: GraphQLScalarTypes } = require('graphql-scalar-types');
+
+const schemaString = gql`
+  # Make sure to define the scalars in the schema string
+  scalar Name
+  scalar Email
+
+  type Person {
+    name: Name
+    email: Email
+  }
+
+  type Query {
+    successfulPerson: Person
+    unsuccessfulPerson: Person
+  }
+`;
+
+const resolverFunctions = {
+  // Now define the resolvers using GraphQLScalarTypes
+  Name: GraphQLScalarTypes.string('Name').min(1).create(),
+  Email: GraphQLScalarTypes.string('Email').regex(/[\w\d]+@[\w\d]+\.\w+/, { name: 'Email Regex' }).create(),
+
+  Query: {
+    successfulPerson: () => ({
+      name: 'Foo Bar',
+      email: 'test@email.com'
+    }),
+    unsuccessfulPerson: () => ({
+      name: '',
+      email: 'invalid-email'
+    })
+  }
+};
+
+const server = new ApolloServer({
+  typeDefs: schemaString,
+  resolvers: resolverFunctions
+});
+
+server.listen().then(({ url }) => {
+  console.log(`🚀 Server ready at ${url}`);
+});
+```
+
 ## API
 
 #### constructor


### PR DESCRIPTION
I love what this library is doing! I am still trying to wrap my head around GraphQL types and directives, and this makes it really easy to create simple custom types with validation. So thanks!

To make it a little bit more approachable, I added a more detailed working example using the latest `apollo-server` library to the readme. It will give users a little more detail on what all they need to do to make this work for them. 

I made sure you could copy and paste this code into a file and test it out as is.
